### PR TITLE
Working installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A proxy server that uses [Artifactory](http://www.jfrog.com/home/v_artifactory_o
 Installation
 ============
 
-    npm install npm-artifactory
+    git clone https://github.com/AceMetrix/npm-artifactory
+    cd npm-artifactory
+    npm install
 
 Usage
 ======


### PR DESCRIPTION
Blindly following the original installation instructions won't work: `node app.js` of course only works when you have npm-artifactory checked out, not just installed.

Is there also a way to start the server without cloning the git repo? If so that might be even better ;).
